### PR TITLE
Add fields to query history

### DIFF
--- a/tap_looker/streams.py
+++ b/tap_looker/streams.py
@@ -361,7 +361,7 @@ STREAMS = {
         'swagger_object': 'Workspace'
     },
     'query_history': {
-        'path': 'queries/run/json?limit=1000&apply_formatting=false&apply_vis=false&cache=false&force_production=true&server_table_calcs=false',
+        'path': 'queries/run/json?limit=10000&apply_formatting=false&apply_vis=false&cache=false&force_production=true&server_table_calcs=false',
         'key_properties': ['query_id', 'history_created_date', 'dims_hash_key'],
         'replication_method': 'FULL_TABLE',
         'method': 'POST',

--- a/tap_looker/streams.py
+++ b/tap_looker/streams.py
@@ -390,7 +390,7 @@ STREAMS = {
             'filters': {
                 'query.model': '-EMPTY',
                 'history.runtime': 'NOT NULL',
-                'history.created_date': '1 month',
+                'history.created_date': '1 week',
                 'user.is_looker': 'No'
             },
             'sorts': [

--- a/tap_looker/streams.py
+++ b/tap_looker/streams.py
@@ -361,7 +361,7 @@ STREAMS = {
         'swagger_object': 'Workspace'
     },
     'query_history': {
-        'path': 'queries/run/json?limit=10000&apply_formatting=false&apply_vis=false&cache=false&force_production=true&server_table_calcs=false',
+        'path': 'queries/run/json?limit=1000&apply_formatting=false&apply_vis=false&cache=false&force_production=true&server_table_calcs=false',
         'key_properties': ['query_id', 'history_created_date', 'dims_hash_key'],
         'replication_method': 'FULL_TABLE',
         'method': 'POST',
@@ -377,13 +377,20 @@ STREAMS = {
                 'look.id',
                 'dashboard.id',
                 'user.id',
+                'history.message',
+                'history.status',
+                'history.rebuild_pdts',
+                'history.most_recent_run_at_date',
+                'history.result_source',
+                'history.server_table_calcs',
+                'history.source',
                 'history.query_run_count',
                 'history.total_runtime'
             ],
             'filters': {
                 'query.model': '-EMPTY',
                 'history.runtime': 'NOT NULL',
-                'history.created_date': '1 week',
+                'history.created_date': '1 month',
                 'user.is_looker': 'No'
             },
             'sorts': [


### PR DESCRIPTION
We need these fields to tell why a query failed (message), its source, and its last run time. 


<img width="232" alt="Screen Shot 2021-03-09 at 10 07 57 PM" src="https://user-images.githubusercontent.com/46604073/110570764-77952180-8124-11eb-8f47-29c8658e52d2.png">
<img width="547" alt="Screen Shot 2021-03-09 at 10 07 08 PM" src="https://user-images.githubusercontent.com/46604073/110570777-7bc13f00-8124-11eb-9c2f-b8309754342d.png">
<img width="506" alt="Screen Shot 2021-03-09 at 10 07 01 PM" src="https://user-images.githubusercontent.com/46604073/110570784-7e239900-8124-11eb-897e-6b4d30e4901d.png">

